### PR TITLE
Require Python 3.10+, update Python requirements

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can install the i18ntools package using pip:
 python -m pip install i18ntools
 ```
 
-i18ntools officially supports Python 3.8+.
+i18ntools officially supports Python 3.10+.
 
 It is recommended to install i18ntools in a [virtual environment](https://docs.python.org/3/library/venv.html#module-venv)
 rather than being installed globally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,14 @@ dependencies = [
     "requests",
 ]
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click==8.1.7
 colorama==0.4.6
 distlib==0.3.8
 exceptiongroup==1.1.1
-filelock==3.15.4
+filelock==3.20.2
 idna==3.7
 iniconfig==2.0.0
 multidict==6.0.5
@@ -19,11 +19,11 @@ pluggy==1.5.0
 pyproject-api==1.7.1
 pytest==8.3.2
 PyYAML==6.0.1
-requests==2.32.3
+requests==2.32.5
 tomli==2.0.1
 tox==4.16.0
 typing_extensions==4.12.2
-urllib3==1.26.19
+urllib3==2.6.3
 vcrpy==6.0.1
 virtualenv==20.29.2
 wrapt==1.16.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = lint-fix, lint-test, py{38,39,310,311}
+env_list = lint-fix, lint-test, py{310,311,313,314}
 
 [testenv]
 description = run unit tests
@@ -24,7 +24,7 @@ commands =
 description = run linters to detect issues
 skip_install = true
 deps =
-    flake8==6
+    flake8>=7
     flake8-pytest-style
 commands =
     flake8 src tests


### PR DESCRIPTION
Require Python 3.10+ because Python 3.9 is now end of life, and update a few Python requirements.