### PR TITLE
Fix minor typos

### DIFF
--- a/src/i18ntools/parse_i18n_file.py
+++ b/src/i18ntools/parse_i18n_file.py
@@ -24,7 +24,7 @@ def parse_i18n_file(file_path):
     file_path -- filepath of the i18n Java properties file to parse
     """
     if not Path(file_path).exists():
-        raise FileNotFoundError("File {0} does not exist".format(file_path), file_path)
+        raise FileNotFoundError(f"File {file_path} does not exist")
 
     # Open the input file in read mode to read its contents
     with open(file_path, "r", encoding="utf-8") as f:

--- a/src/i18ntools/parse_i18n_file.py
+++ b/src/i18ntools/parse_i18n_file.py
@@ -32,7 +32,7 @@ def parse_i18n_file(file_path):
 
     data = {}
     duplicate_keys = set()
-    mostRecentKey = None
+    most_recent_key = None
     for line in file_contents:
         # Skip comments and empty lines
         if line.startswith("#") or line.strip() == "":
@@ -44,7 +44,7 @@ def parse_i18n_file(file_path):
             # This line is part of a multiline value.
             # Add the additional line to the value in our dictionary,
             # stripping the trailing whitespace.
-            data[mostRecentKey] += "\n" + line.rstrip()
+            data[most_recent_key] += "\n" + line.rstrip()
             continue
 
         key = parts[0]
@@ -52,7 +52,7 @@ def parse_i18n_file(file_path):
         if key in data:
             duplicate_keys.add(key)
         data[key] = value
-        mostRecentKey = key
+        most_recent_key = key
 
     if len(duplicate_keys) > 0:
         raise SyntaxWarning(

--- a/src/i18ntools/sort_i18n_file.py
+++ b/src/i18ntools/sort_i18n_file.py
@@ -39,9 +39,7 @@ def sort_i18n_file(input_file_path, output_lang, output_file_path=None):
             For example, messages.properties would become messages_de.properties
     """
     if not Path(input_file_path).exists():
-        raise FileNotFoundError(
-            "File {0} does not exist".format(input_file_path), input_file_path
-        )
+        raise FileNotFoundError(f"File {input_file_path} does not exist")
 
     if output_file_path is None:
         # Make output_file_path be the input_file_path with the
@@ -50,9 +48,7 @@ def sort_i18n_file(input_file_path, output_lang, output_file_path=None):
         output_file_path = get_default_filepath(input_file_path, output_lang)
 
     if not Path(output_file_path).exists():
-        raise FileNotFoundError(
-            "File {0} does not exist".format(output_file_path), output_file_path
-        )
+        raise FileNotFoundError(f"File {output_file_path} does not exist")
 
     # Parse the output file into a dictionary
     output_data = parse_i18n_file(output_file_path)

--- a/src/i18ntools/translate.py
+++ b/src/i18ntools/translate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """This script translates an i18n Java properties file into a new
 i18n Java properties file of a different language
-by making Rest API calls to Microsoft Azure Cognitive Services Translator.
+by making REST API calls to Microsoft Azure Cognitive Services Translator.
 
 Requires the API secret key to be set in an environment variable
 named TRANSLATOR_API_SUBSCRIPTION_KEY .
@@ -29,7 +29,7 @@ def get_default_filepath(input_file_path, output_lang):
     """Returns the filepath for a new i18n Java properties file
     based on the filepath of the input file and the output language.
 
-    The filepath returned with be in the same directory as the input file.
+    The filepath returned will be in the same directory as the input file.
     The filename will be the same as the input file but with the
     output_lang appended to it. For example, "/dir/messages.properties"
     would become "/dir/messages_de.properties"

--- a/src/i18ntools/translate.py
+++ b/src/i18ntools/translate.py
@@ -111,9 +111,7 @@ def translate_file(
     translator_region=default_region,
 ):
     if not Path(input_file_path).exists():
-        raise FileNotFoundError(
-            "File {0} does not exist".format(input_file_path), input_file_path
-        )
+        raise FileNotFoundError(f"File {input_file_path} does not exist")
 
     if output_file_path is None:
         # Make output_file_path be the input_file_path with the

--- a/src/i18ntools/translate_missing.py
+++ b/src/i18ntools/translate_missing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """This script translates the messages in an i18n Java properties file that are
 missing from an i18n Java properties file of a different language
-by making Rest API calls to Microsoft Azure Cognitive Services Translator.
+by making REST API calls to Microsoft Azure Cognitive Services Translator.
 
 Requires the API secret key to be set in an environment variable
 named TRANSLATOR_API_SUBSCRIPTION_KEY .
@@ -138,7 +138,7 @@ def main():
             "filename of the output properties file with the missing messages. "
             "Can be specified as a relative or absolute file path. "
             "Defaults to the input_file with the output_lang appended to it. "
-            "For example, messages.properties would become messages_de.properties . "
+            "For example, messages.properties would become messages_de.properties. "
             "If the file does not exist, the program will exit with an error."
         ),
     )

--- a/src/i18ntools/translate_missing.py
+++ b/src/i18ntools/translate_missing.py
@@ -32,9 +32,7 @@ def translate_missing_messages(
     translator_region=default_region,
 ):
     if not Path(input_file_path).exists():
-        raise FileNotFoundError(
-            "File {0} does not exist".format(input_file_path), input_file_path
-        )
+        raise FileNotFoundError(f"File {input_file_path} does not exist")
 
     if output_file_path is None:
         # Make output_file_path be the input_file_path with the
@@ -45,9 +43,7 @@ def translate_missing_messages(
         )
 
     if not Path(output_file_path).exists():
-        raise FileNotFoundError(
-            "File {0} does not exist".format(output_file_path), output_file_path
-        )
+        raise FileNotFoundError(f"File {output_file_path} does not exist")
 
     # Parse the input file and output file into a dictionary
     input_data = parse_i18n_file(input_file_path)


### PR DESCRIPTION
Fix minor typos, rename a variable in `src/i18ntools/parse_i18n_file.py` to consistently use snake_case naming convention, and simplify the message supplied to FileNotFoundError across the project.